### PR TITLE
Make board/*/post-*.sh explicitly use dash shell.

### DIFF
--- a/board/RK3308/post-build.sh
+++ b/board/RK3308/post-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/dash
 
 # fix eth0
 cnt=`grep -c eth0 $TARGET_DIR/etc/network/interfaces`

--- a/board/RK3308/post-image.sh
+++ b/board/RK3308/post-image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/dash
 
 RKBIN=$BINARIES_DIR/rkbin
 RKTOOLS=$RKBIN/tools

--- a/board/RK3328/post-build.sh
+++ b/board/RK3328/post-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/dash
 
 # fix eth0
 cnt=`grep -c eth0 $TARGET_DIR/etc/network/interfaces`

--- a/board/RK3328/post-image.sh
+++ b/board/RK3328/post-image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/dash
 
 RKBIN=$BINARIES_DIR/rkbin
 RKTOOLS=$RKBIN/tools

--- a/board/RK3566/post-build.sh
+++ b/board/RK3566/post-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/dash
 
 # fix eth0
 cnt=`grep -c eth0 $TARGET_DIR/etc/network/interfaces`

--- a/board/RK3566/post-image.sh
+++ b/board/RK3566/post-image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/dash
 
 RKBIN=$BINARIES_DIR/rkbin
 RKTOOLS=$RKBIN/tools

--- a/board/RK3568/post-build.sh
+++ b/board/RK3568/post-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/dash
 
 # fix eth0
 cnt=`grep -c eth0 $TARGET_DIR/etc/network/interfaces`

--- a/board/RK3568/post-image.sh
+++ b/board/RK3568/post-image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/dash
 
 RKBIN=$BINARIES_DIR/rkbin
 RKCHIP_LOADER=$2


### PR DESCRIPTION
These scripts (at least the post-image.sh ones) rely on dash features.
On Debian distros where sh->dash, that's ok.  On other distros where
sh->bash, they fail in curious ways.  Make it explicitly require dash
unless someone has a motive to figure out a way to make it more
generic/portable.