### PR TITLE
Minor change to how to pull buildroot.rockchip for public use (no ssh key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sudo apt-get install -y cpio unzip rsync python3
 
 Clone the external buildroot tree :
 ```
-git clone git@github.com:flatmax/buildroot.rockchip.git buildroot.rockchip.ext
+git clone https://github.com/flatmax/buildroot.rockchip.git buildroot.rockchip.ext
 ```
 
 # To make the system


### PR DESCRIPTION
Changed a minor error on how to clone the flatmax/buildroot.rockchip repo for the public (won't have the author's ssh key).